### PR TITLE
Actions: use ubuntu:18.04 container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,16 @@ name: Compile and test
 on: [push, pull_request]
 
 env:
-  CLONE_NAME: maliput-dragway
   PACKAGE_NAME: maliput_dragway
   ROS_DISTRO: dashing
-  ROS_WS: ros_ws
+  ROS_WS: maliput_ws
 
 jobs:
   compile_and_test:
     name: Compile and test
     runs-on: ubuntu-18.04
+    container:
+      image: ubuntu:18.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -22,31 +23,30 @@ jobs:
         repository: ToyotaResearchInstitute/maliput
         path: ${{ env.ROS_WS }}/src/maliput
         token: ${{ secrets.MALIPUT_TOKEN }}
-    - uses: ros-tooling/setup-ros2@0.0.11
+    - uses: ros-tooling/setup-ros@0.0.25
     # clone public dependencies
     - name: vcs import
       shell: bash
-      working-directory: ${{runner.workspace}}/${{ env.CLONE_NAME }}/${{ env.ROS_WS }}
+      working-directory: ${{ env.ROS_WS }}
       run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
-    - name: colcon graph
+    - run: colcon graph
       shell: bash
-      working-directory: ${{runner.workspace}}/${{ env.CLONE_NAME }}/${{ env.ROS_WS }}
-      run: colcon graph
+      working-directory: ${{ env.ROS_WS }}
     - name: rosdep install
       shell: bash
-      working-directory: ${{runner.workspace}}/${{ env.CLONE_NAME }}/${{ env.ROS_WS }}
+      working-directory: ${{ env.ROS_WS }}
       run: |
         rosdep update;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build
       shell: bash
-      working-directory: ${{runner.workspace}}/${{ env.CLONE_NAME }}/${{ env.ROS_WS }}
+      working-directory: ${{ env.ROS_WS }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon build --packages-up-to ${PACKAGE_NAME} --event-handlers=console_direct+;
     - name: colcon test
       shell: bash
-      working-directory: ${{runner.workspace}}/${{ env.CLONE_NAME }}/${{ env.ROS_WS }}
+      working-directory: ${{ env.ROS_WS }}
       run: |
         . /opt/ros/${ROS_DISTRO}/setup.bash;
         colcon test --packages-select ${PACKAGE_NAME} --event-handlers=console_direct+;


### PR DESCRIPTION
Follow-up to #9. Using a container is required for some other packages (see https://github.com/ToyotaResearchInstitute/malidrive/pull/607), so use it here as well to be consistent.