### PR TITLE
Fixes sanitizers variable.

### DIFF
--- a/cmake/SanitizersConfig.cmake
+++ b/cmake/SanitizersConfig.cmake
@@ -22,6 +22,7 @@ endmacro()
 # Sanitizers Configuration
 ##############################################################################
 
+set(SANITIZERS off)
 if ("${CMAKE_CXX_COMPILER_ID} " MATCHES "Clang ")
   option(ADDRESS_SANITIZER "Enable Clang Address Sanitizer" OFF)
   option(UNDEFINED_SANITIZER "Enable Clang Undefined Behaviour Sanitizer" OFF)


### PR DESCRIPTION
When the variable SANITIZERS isn't declared doesn't mean that the value is False or off.