### PR TITLE
Don't pass self to ament_target_dependencies

### DIFF
--- a/src/maliput_dragway_test_utilities/CMakeLists.txt
+++ b/src/maliput_dragway_test_utilities/CMakeLists.txt
@@ -14,7 +14,6 @@ target_include_directories(
 
 ament_target_dependencies(maliput_dragway_test_utilities
   "maliput"
-  "maliput_dragway"
 )
 
 target_link_libraries(maliput_dragway_test_utilities


### PR DESCRIPTION
In preparation of supporting Ubuntu 20.04 and ROS Foxy, I've made the [eloquent branch](https://github.com/ToyotaResearchInstitute/maliput-dragway/compare/eloquent) for testing with ROS Eloquent. There is a cmake error that this branch fixes (see the failure on bcdea4b00d47e39e3369ba94b2053597c2c62f8a fixed by c25f524e8685119e375cb2441c2166fbc8ca61e3) similar to https://github.com/ToyotaResearchInstitute/maliput/pull/370.