### PR TITLE
Unifies cmake install paths.

### DIFF
--- a/src/maliput_dragway/CMakeLists.txt
+++ b/src/maliput_dragway/CMakeLists.txt
@@ -38,11 +38,11 @@ ament_target_dependencies(maliput_dragway
 ##############################################################################
 
 install(
-    TARGETS maliput_dragway
-    EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  TARGETS maliput_dragway
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(maliput_dragway)

--- a/src/maliput_dragway_test_utilities/CMakeLists.txt
+++ b/src/maliput_dragway_test_utilities/CMakeLists.txt
@@ -23,10 +23,11 @@ target_link_libraries(maliput_dragway_test_utilities
 )
 
 install(
-    TARGETS maliput_dragway_test_utilities
-    EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
+  TARGETS maliput_dragway_test_utilities
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(maliput_dragway_test_utilities)


### PR DESCRIPTION
Relates to https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146

Pairs with https://github.com/ToyotaResearchInstitute/maliput/pull/371