### PR TITLE
Fixes plugin test failure when running ubsan.

### DIFF
--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -18,6 +18,12 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/include
       )
 
+      # To avoid a false positive when running ubsan the symbols must be exported
+      # See https://stackoverflow.com/questions/57361776/use-ubsan-with-dynamically-loaded-shared-libraries
+      set_target_properties(${target}
+        PROPERTIES
+          ENABLE_EXPORTS ON
+      )
       ament_target_dependencies(${target}
         "maliput"
       )


### PR DESCRIPTION
Resolves #28 

Reference: https://stackoverflow.com/questions/57361776/use-ubsan-with-dynamically-loaded-shared-libraries