### PR TITLE
Use newer revision of pybind11

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -6,4 +6,4 @@ repositories:
   pybind11:
     type: git
     url: https://github.com/RobotLocomotion/pybind11.git
-    version: 69a5d92a5ff9fe84581a1edeb6051a8c21d9eb97
+    version: c39ede1eedd4f39aa167d7b30b53ae45967c39b7


### PR DESCRIPTION
This version works on 20.04; this is a test if it works also on 18.04. This is an alternative to part of https://github.com/ToyotaResearchInstitute/maliput_py/pull/9

Part of ToyotaResearchInstitute/maliput_infrastructure#215