### PR TITLE
rosdep update --include-eol-distros

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -78,7 +78,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -65,7 +65,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build up-to
       shell: bash


### PR DESCRIPTION
`dashing` is now end-of-life so we should use `--include-eol-distros` with `rosdep update`

See https://github.com/ToyotaResearchInstitute/maliput/pull/425

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196