### PR TITLE
Remove references to GnuInstallDir vars.

### DIFF
--- a/src/maliput_dragway/CMakeLists.txt
+++ b/src/maliput_dragway/CMakeLists.txt
@@ -22,7 +22,8 @@ set_target_properties(maliput_dragway
 target_include_directories(maliput_dragway
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:include>
+)
 
 target_link_libraries(maliput_dragway
   maliput::api

--- a/src/maliput_dragway_test_utilities/CMakeLists.txt
+++ b/src/maliput_dragway_test_utilities/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(
   maliput_dragway_test_utilities
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(maliput_dragway_test_utilities

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -21,7 +21,8 @@ target_link_libraries(road_network
 target_include_directories(road_network
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:include>
+)
 
 ##############################################################################
 # Export


### PR DESCRIPTION
Because it is not brought by default in ROS2 foxy,
we can just use the name of the folder 'include'
to reference where to look at for include directories.


Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196

Solves https://github.com/ToyotaResearchInstitute/maliput_dragway/issues/52 