### PR TITLE
Enable doxygen verification.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if(BUILD_DOCS)
   ament_doxygen_generate(doxygen_maliput_dragway
     CONFIG_OVERLAY doc/Doxyfile.overlay.in
     DEPENDENCIES maliput
+    TEST_ON_WARNS
   )
 endif()
 

--- a/include/maliput_dragway/road_geometry.h
+++ b/include/maliput_dragway/road_geometry.h
@@ -50,6 +50,8 @@ class RoadGeometry final : public api::RoadGeometry {
   /// @param[in] angular_tolerance The tolerance guaranteed for angular
   /// measurements (orientations).
   ///
+  /// @param[in] inertial_to_backend_frame_translation the Inertial Frame to Backend
+  ///        Frame translation vector
   RoadGeometry(const api::RoadGeometryId& id, int num_lanes, double length, double lane_width, double shoulder_width,
                double maximum_height, double linear_tolerance, double angular_tolerance,
                const math::Vector3& inertial_to_backend_frame_translation);


### PR DESCRIPTION
Pairs with https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen/pull/6
Related to https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/227

One doxygen warning :
```
test 2
    Start 2: maliput_dragway_doxygen_warnings

2: Test command: /bin/bash "/home/franco/maliput_ws/install/ament_cmake_doxygen/share/ament_cmake_doxygen/cmake/../tools/check_doc_warns.sh" "/home/franco/maliput_ws/build/maliput_dragway/ament_cmake_doxygen/maliput_dragway/warnings.log"
2: Test timeout computed to be: 9.99988e+06
2: Error. The following warnings were found in /home/franco/maliput_ws/build/maliput_dragway/ament_cmake_doxygen/maliput_dragway/warnings.log.
2: /home/franco/maliput_ws/src/maliput_dragway/include/maliput_dragway/road_geometry.h:52: warning: The following parameters of maliput::dragway::RoadGeometry::RoadGeometry(const api::RoadGeometryId &id, int num_lanes, double length, double lane_width, double shoulder_width, double maximum_height, double linear_tolerance, double angular_tolerance, const math::Vector3 &inertial_to_backend_frame_translation) are not documented:
2:   parameter 'inertial_to_backend_frame_translation'
2/5 Test #2: maliput_dragway_doxygen_warnings ...***Failed    0.00 sec

```