### PR TITLE
Improves use of maliput plugin architecture.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ endif()
 # Export
 ##############################################################################
 
+ament_environment_hooks(setup.sh.in)
+
 install(
   DIRECTORY include/
   DESTINATION include

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# A function to add a new item (needle) to the passed environment variable, only
+# if the new item is not already in the environment variable.  The function
+# expects the elements of the environment variable to be separated via ':'.
+add_if_not_in_var() {
+  var=$1
+  needle=$2
+
+  # Get the current list of items in the variable using the "two-pass"
+  # bash trick.  In the first pass (before the eval), $var (using the inner
+  # dollar) is expanded to the name of the environment variable.  Then the
+  # eval is run, and the outer dollar expands to the contents of the named
+  # variable.  Note that we have to escape the outer one so it doesn't get
+  # expanded by the first shell.
+  current=$( eval echo \$"$var" )
+
+  # Iterate over every item in the environment variable, looking to see
+  # if the needle is already in there.  Note that we do it this way instead
+  # of a substring because the substring can have some false positives (think
+  # about the case where "foobar" is already there while trying to add
+  # "foo").
+  IFS_PREV_VAL=$IFS
+  if [ -z ${IFS+x} ]; then
+    IFS_WAS_SET=0
+  else
+    IFS_WAS_SET=1
+  fi
+  found=0
+  for addr in $current; do
+    if [ "$addr" = "$needle" ]; then
+      found=1
+      break
+    fi
+  done
+
+  # If we didn't find the needle in the list, add it here.
+  if [ "$found" -eq 0 ]; then
+      if [ "$current" = "" ]; then
+          export "$var"="$needle"
+      else
+          export "$var"="$( eval echo \$$var )":"$needle"
+      fi
+  fi
+
+  if [ "$IFS_WAS_SET" -eq 0 ]; then
+    unset IFS
+  else
+    IFS="$IFS_PREV_VAL"
+  fi
+}
+
+# Extends path for the maliput plugin architecture
+add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_dragway/lib/plugins:$MALIPUT_PLUGIN_PATH

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -28,8 +28,11 @@ target_include_directories(road_network
 # Export
 ##############################################################################
 
+# Using a different location as this target is a dynamic library
+# which will be loaded in runtime as a maliput plugin.
 set(PLUGIN_INSTALL_DIR
-    "${CMAKE_INSTALL_PREFIX}/../maliput/lib/maliput/plugins")
+    lib/plugins
+)
 
 install(
   TARGETS road_network

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -1,14 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 
-# The following test uses the maliput::plugin::MaliputPluginManager entity to load all the availables plugins.
-# Given that the LD_LIBRARY_PATH environment variable isn't correctly set up until setup.bash is sourced,
-# and to avoid sourcing that file just to run one test we should append the paths.
-# This allow to any other backend plugin to find its correspondant backend core library.
-ament_add_gtest(road_network_plugin road_network_plugin_test.cc
-    APPEND_LIBRARY_DIRS
-      ${CMAKE_INSTALL_PREFIX}/../maliput_malidrive/lib
-      ${CMAKE_INSTALL_PREFIX}/../maliput_multilane/lib
-)
+ament_add_gtest(road_network_plugin road_network_plugin_test.cc)
 
 macro(add_dependencies_to_test target)
     if (TARGET ${target})


### PR DESCRIPTION
Improves use of maliput plugin architecture:

 - Change Install folder where the `maliput::plugin::RoadNetworkLoader` is installed
 - Extends `MALIPUT_PLUGIN_PATH` env var to use the discovery process of the plugins as the documentation recommends.