### PR TITLE
Fixes MALIPUT_PLUGIN_PATH new path.

### DIFF
--- a/setup.sh.in
+++ b/setup.sh.in
@@ -51,4 +51,4 @@ add_if_not_in_var() {
 }
 
 # Extends path for the maliput plugin architecture
-add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_dragway/lib/plugins:$MALIPUT_PLUGIN_PATH
+add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_dragway/lib/plugins


### PR DESCRIPTION
the `add_if_not_in_var` function in `setup.sh.ini` already extend the variable.

It was added at #57 