### PR TITLE
add missing dependency on python3-dev to get python.h

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>maliput</depend>
   <depend>maliput_py</depend>
   <depend>pybind11-dev</depend>
+  <depend>python3-dev</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/src/maliput_dragway_test_utilities/CMakeLists.txt
+++ b/src/maliput_dragway_test_utilities/CMakeLists.txt
@@ -1,3 +1,5 @@
+if(BUILD_TESTING)
+
 set(TEST_UTILS_SOURCES
   fixtures.cc)
 
@@ -24,3 +26,5 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+
+endif()


### PR DESCRIPTION
Fixes: https://build.ros2.org/job/Fbin_uF64__maliput_dragway__ubuntu_focal_amd64__binary/1/console

```
17:54:34 In file included from [01m[K/usr/include/pybind11/pytypes.h:12[m[K,
17:54:34                  from [01m[K/usr/include/pybind11/cast.h:13[m[K,
17:54:34                  from [01m[K/usr/include/pybind11/attr.h:13[m[K,
17:54:34                  from [01m[K/usr/include/pybind11/pybind11.h:44[m[K,
17:54:34                  from [01m[K/tmp/binarydeb/ros-foxy-maliput-dragway-0.1.0/src/bindings/dragway_py.cc:31[m[K:
17:54:34 [01m[K/usr/include/pybind11/detail/common.h:112:10:[m[K [01;31m[Kfatal error: [m[KPython.h: No such file or directory
17:54:34   112 | #include [01;31m[K<Python.h>[m[K
17:54:34       |          [01;31m[K^~~~~~~~~~[m[K
17:54:34 compilation terminated.
```

