### PR TITLE
Implements plugin interface for providing default parameters.

### DIFF
--- a/include/maliput_dragway/road_network_builder.h
+++ b/include/maliput_dragway/road_network_builder.h
@@ -38,8 +38,57 @@
 namespace maliput {
 namespace dragway {
 
+/// @defgroup road_geometry_configuration_keys RoadGeometry configuration builder keys
+///
+/// Parameters used during the RoadGeometry building process.
+///
+/// When parameters are omitted the default value will be used.
+///
+/// Example of use:
+/// @code{cpp}
+/// const std::map<std::string, std::string> builder_configuration {
+///   {"maliput::dragway::kNumLanes", "4"},
+///   {"maliput::dragway::kLength", "150"},
+///   {"maliput::dragway::kLaneWidth", "3"},
+/// };
+/// auto road_network = maliput::dragway::BuildRoadNetwork::(builder_configuration)();
+/// @endcode
+///
+/// @{
+
+/// Number of lanes.
+///   - Default: @e "2"
+static constexpr char const* kNumLanes{"num_lanes"};
+/// Length of the dragway.
+///   - Default: @e "10"
+static constexpr char const* kLength{"length"};
+/// Width of the lanes.
+///   - Default: @e "3.7"
+static constexpr char const* kLaneWidth{"lane_width"};
+/// Width of the shoulders of the road.
+///   - Default: @e "3."
+static constexpr char const* kShoulderWidth{"shoulder_width"};
+/// Maximum height above the road surface.
+///   - Default: @e "5.2"
+static constexpr char const* kMaximumHeight{"maximum_height"};
+/// Translation from maliput to maliput_osm inertial frame.
+/// The format of the 3-dimensional vector that is expected to be passed
+/// should be {X, Y, Z}. Same format as maliput::math::Vector3 is
+/// serialized.
+///   - Default: @e "{0., 0., 0.}"
+static constexpr char const* kInertialToBackendFrameTranslation{"inertial_to_backend_frame_translation"};
+
+/// @}
+
 /// Contains the attributes needed for building a dragway::RoadGeometry.
 struct RoadGeometryConfiguration {
+  /// Create a RoadGeometryConfiguration from a string dictionary.
+  static maliput::dragway::RoadGeometryConfiguration FromMap(const std::map<std::string, std::string>& parameters);
+
+  /// @details The keys of the map are listed at @ref road_geometry_configuration_keys.
+  /// @returns A string-string map containing the road geometry configuration.
+  std::map<std::string, std::string> ToStringMap() const;
+
   /// Number of lanes.
   int num_lanes{2};
   /// Length of the lanes.

--- a/src/maliput_dragway/road_network_builder.cc
+++ b/src/maliput_dragway/road_network_builder.cc
@@ -52,6 +52,46 @@
 namespace maliput {
 namespace dragway {
 
+RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(const std::map<std::string, std::string>& parameters) {
+  RoadGeometryConfiguration rg_configuration{};
+  auto it = parameters.find(kNumLanes);
+  if (it != parameters.end()) {
+    rg_configuration.num_lanes = std::stoi(it->second);
+  }
+  it = parameters.find(kLength);
+  if (it != parameters.end()) {
+    rg_configuration.length = std::stod(it->second);
+  }
+  it = parameters.find(kLaneWidth);
+  if (it != parameters.end()) {
+    rg_configuration.lane_width = std::stod(it->second);
+  }
+  it = parameters.find(kShoulderWidth);
+  if (it != parameters.end()) {
+    rg_configuration.shoulder_width = std::stod(it->second);
+  }
+  it = parameters.find(kMaximumHeight);
+  if (it != parameters.end()) {
+    rg_configuration.maximum_height = std::stod(it->second);
+  }
+  it = parameters.find(kInertialToBackendFrameTranslation);
+  if (it != parameters.end()) {
+    rg_configuration.inertial_to_backend_frame_translation = maliput::math::Vector3::FromStr(it->second);
+  }
+  return rg_configuration;
+}
+
+std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() const {
+  std::map<std::string, std::string> parameters;
+  parameters[kNumLanes] = std::to_string(num_lanes);
+  parameters[kLength] = std::to_string(length);
+  parameters[kLaneWidth] = std::to_string(lane_width);
+  parameters[kShoulderWidth] = std::to_string(shoulder_width);
+  parameters[kMaximumHeight] = std::to_string(maximum_height);
+  parameters[kInertialToBackendFrameTranslation] = inertial_to_backend_frame_translation.to_str();
+  return parameters;
+}
+
 std::unique_ptr<api::RoadNetwork> BuildRoadNetwork(const RoadGeometryConfiguration& road_geometry_configuration) {
   maliput::log()->debug("Building dragway RoadNetwork.");
   auto rg = std::make_unique<dragway::RoadGeometry>(

--- a/src/plugin/road_network.cc
+++ b/src/plugin/road_network.cc
@@ -40,53 +40,19 @@
 namespace maliput {
 namespace dragway {
 namespace plugin {
-namespace {
-
-// Return a dragway::RoadGeometryConfiguration object out of a map of strings.
-// When a property is missing it uses the default value from dragway::RoadGeometryConfiguration.
-// @param parameters  A dictionary of properties to fill in a dragway::RoadGeometryConfiguration struct.
-//                    Keys are the names of attributes in dragway::RoadGeometryConfiguration.
-// @returns A dragway::RoadGeometryConfiguration.
-maliput::dragway::RoadGeometryConfiguration GetPropertiesFromStringMap(
-    const std::map<std::string, std::string>& parameters) {
-  RoadGeometryConfiguration rg_configuration{};
-  auto it = parameters.find("num_lanes");
-  if (it != parameters.end()) {
-    rg_configuration.num_lanes = std::stoi(it->second);
-  }
-  it = parameters.find("length");
-  if (it != parameters.end()) {
-    rg_configuration.length = std::stod(it->second);
-  }
-  it = parameters.find("lane_width");
-  if (it != parameters.end()) {
-    rg_configuration.lane_width = std::stod(it->second);
-  }
-  it = parameters.find("shoulder_width");
-  if (it != parameters.end()) {
-    rg_configuration.shoulder_width = std::stod(it->second);
-  }
-  it = parameters.find("maximum_height");
-  if (it != parameters.end()) {
-    rg_configuration.maximum_height = std::stod(it->second);
-  }
-  it = parameters.find("inertial_to_backend_frame_translation");
-  if (it != parameters.end()) {
-    rg_configuration.inertial_to_backend_frame_translation = maliput::math::Vector3::FromStr(it->second);
-  }
-  return rg_configuration;
-}
 
 // Implementation of a maliput::plugin::RoadNetworkLoader using dragway backend.
 class RoadNetworkLoader : public maliput::plugin::RoadNetworkLoader {
  public:
   std::unique_ptr<maliput::api::RoadNetwork> operator()(
       const std::map<std::string, std::string>& properties) const override {
-    return maliput::dragway::BuildRoadNetwork(GetPropertiesFromStringMap(properties));
+    return maliput::dragway::BuildRoadNetwork(RoadGeometryConfiguration::FromMap(properties));
+  }
+
+  std::map<std::string, std::string> GetDefaultParameters() const override {
+    return RoadGeometryConfiguration{}.ToStringMap();
   }
 };
-
-}  // namespace
 
 REGISTER_ROAD_NETWORK_LOADER_PLUGIN("maliput_dragway", RoadNetworkLoader);
 


### PR DESCRIPTION
# 🎉 New feature

Closes #78 

## Summary

`RoadNetworkPlugin::GetDefaultParameters` method is implemented so it can be obtained via plugin interface

Usecase: Maliput viz application:
![image](https://user-images.githubusercontent.com/53065142/206461003-638724d1-a9ab-4cf6-96e6-acdb383e914a.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

