### PR TITLE
Moves builder's parameters to a separate file.

### DIFF
--- a/include/maliput_dragway/params.h
+++ b/include/maliput_dragway/params.h
@@ -32,6 +32,7 @@
 
 namespace maliput {
 namespace dragway {
+namespace params {
 
 /// @defgroup road_geometry_configuration_keys RoadGeometry configuration builder keys
 ///
@@ -45,9 +46,9 @@ namespace dragway {
 /// #include <maliput_dragway/road_network_builder.h>
 /// // ...
 /// const std::map<std::string, std::string> builder_configuration {
-///   {maliput::dragway::kNumLanes, "4"},
-///   {maliput::dragway::kLength, "150"},
-///   {maliput::dragway::kLaneWidth, "3"},
+///   {maliput::dragway::params::kNumLanes, "4"},
+///   {maliput::dragway::params::kLength, "150"},
+///   {maliput::dragway::params::kLaneWidth, "3"},
 /// };
 /// auto road_network = maliput::dragway::BuildRoadNetwork(builder_configuration)();
 /// @endcode
@@ -78,5 +79,6 @@ static constexpr char const* kInertialToBackendFrameTranslation{"inertial_to_bac
 
 /// @}
 
+}  // namespace params
 }  // namespace dragway
 }  // namespace maliput

--- a/include/maliput_dragway/params.h
+++ b/include/maliput_dragway/params.h
@@ -38,33 +38,50 @@
 namespace maliput {
 namespace dragway {
 
-/// Contains the attributes needed for building a dragway::RoadGeometry.
-struct RoadGeometryConfiguration {
-  /// Create a RoadGeometryConfiguration from a string dictionary.
-  static maliput::dragway::RoadGeometryConfiguration FromMap(const std::map<std::string, std::string>& parameters);
+/// @defgroup road_geometry_configuration_keys RoadGeometry configuration builder keys
+///
+/// Parameters used during the RoadGeometry building process.
+///
+/// When parameters are omitted the default value will be used.
+///
+/// Example of use:
+/// @code{cpp}
+/// #include <maliput_dragway/params.h>
+/// #include <maliput_dragway/road_network_builder.h>
+/// // ...
+/// const std::map<std::string, std::string> builder_configuration {
+///   {maliput::dragway::kNumLanes, "4"},
+///   {maliput::dragway::kLength, "150"},
+///   {maliput::dragway::kLaneWidth, "3"},
+/// };
+/// auto road_network = maliput::dragway::BuildRoadNetwork(builder_configuration)();
+/// @endcode
+///
+/// @{
 
-  /// @details The keys of the map are listed at @ref road_geometry_configuration_keys.
-  /// @returns A string-string map containing the road geometry configuration.
-  std::map<std::string, std::string> ToStringMap() const;
+/// Number of lanes.
+///   - Default: @e "2"
+static constexpr char const* kNumLanes{"num_lanes"};
+/// Length of the dragway.
+///   - Default: @e "10"
+static constexpr char const* kLength{"length"};
+/// Width of the lanes.
+///   - Default: @e "3.7"
+static constexpr char const* kLaneWidth{"lane_width"};
+/// Width of the shoulders of the road.
+///   - Default: @e "3."
+static constexpr char const* kShoulderWidth{"shoulder_width"};
+/// Maximum height above the road surface.
+///   - Default: @e "5.2"
+static constexpr char const* kMaximumHeight{"maximum_height"};
+/// Translation from maliput to maliput_osm inertial frame.
+/// The format of the 3-dimensional vector that is expected to be passed
+/// should be {X, Y, Z}. Same format as maliput::math::Vector3 is
+/// serialized.
+///   - Default: @e "{0., 0., 0.}"
+static constexpr char const* kInertialToBackendFrameTranslation{"inertial_to_backend_frame_translation"};
 
-  /// Number of lanes.
-  int num_lanes{2};
-  /// Length of the lanes.
-  double length{10};
-  /// Width of the lanes.
-  double lane_width{3.7};
-  /// Width of the shoulders of the road.
-  double shoulder_width{3.};
-  /// Maximum height above the road surface.
-  double maximum_height{5.2};
-  /// Inertial to Backend Frame translation.
-  math::Vector3 inertial_to_backend_frame_translation{0., 0., 0.};
-};
-
-/// Builds an api::RoadNetwork based on Dragway implementation.
-/// @param road_geometry_configuration Holds the properties to build the RoadNetwork.
-/// @return A maliput::api::RoadNetwork.
-std::unique_ptr<api::RoadNetwork> BuildRoadNetwork(const RoadGeometryConfiguration& road_geometry_configuration);
+/// @}
 
 }  // namespace dragway
 }  // namespace maliput

--- a/include/maliput_dragway/params.h
+++ b/include/maliput_dragway/params.h
@@ -30,11 +30,6 @@
 // Copyright 2021 Toyota Research Institute
 #pragma once
 
-#include <memory>
-
-#include <maliput/api/road_geometry.h>
-#include <maliput/api/road_network.h>
-
 namespace maliput {
 namespace dragway {
 

--- a/src/maliput_dragway/road_network_builder.cc
+++ b/src/maliput_dragway/road_network_builder.cc
@@ -47,6 +47,7 @@
 #include <maliput/common/maliput_abort.h>
 #include <maliput/math/vector.h>
 
+#include "maliput_dragway/params.h"
 #include "maliput_dragway/road_geometry.h"
 
 namespace maliput {

--- a/src/maliput_dragway/road_network_builder.cc
+++ b/src/maliput_dragway/road_network_builder.cc
@@ -55,27 +55,27 @@ namespace dragway {
 
 RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(const std::map<std::string, std::string>& parameters) {
   RoadGeometryConfiguration rg_configuration{};
-  auto it = parameters.find(kNumLanes);
+  auto it = parameters.find(params::kNumLanes);
   if (it != parameters.end()) {
     rg_configuration.num_lanes = std::stoi(it->second);
   }
-  it = parameters.find(kLength);
+  it = parameters.find(params::kLength);
   if (it != parameters.end()) {
     rg_configuration.length = std::stod(it->second);
   }
-  it = parameters.find(kLaneWidth);
+  it = parameters.find(params::kLaneWidth);
   if (it != parameters.end()) {
     rg_configuration.lane_width = std::stod(it->second);
   }
-  it = parameters.find(kShoulderWidth);
+  it = parameters.find(params::kShoulderWidth);
   if (it != parameters.end()) {
     rg_configuration.shoulder_width = std::stod(it->second);
   }
-  it = parameters.find(kMaximumHeight);
+  it = parameters.find(params::kMaximumHeight);
   if (it != parameters.end()) {
     rg_configuration.maximum_height = std::stod(it->second);
   }
-  it = parameters.find(kInertialToBackendFrameTranslation);
+  it = parameters.find(params::kInertialToBackendFrameTranslation);
   if (it != parameters.end()) {
     rg_configuration.inertial_to_backend_frame_translation = maliput::math::Vector3::FromStr(it->second);
   }
@@ -84,12 +84,12 @@ RoadGeometryConfiguration RoadGeometryConfiguration::FromMap(const std::map<std:
 
 std::map<std::string, std::string> RoadGeometryConfiguration::ToStringMap() const {
   std::map<std::string, std::string> parameters;
-  parameters[kNumLanes] = std::to_string(num_lanes);
-  parameters[kLength] = std::to_string(length);
-  parameters[kLaneWidth] = std::to_string(lane_width);
-  parameters[kShoulderWidth] = std::to_string(shoulder_width);
-  parameters[kMaximumHeight] = std::to_string(maximum_height);
-  parameters[kInertialToBackendFrameTranslation] = inertial_to_backend_frame_translation.to_str();
+  parameters[params::kNumLanes] = std::to_string(num_lanes);
+  parameters[params::kLength] = std::to_string(length);
+  parameters[params::kLaneWidth] = std::to_string(lane_width);
+  parameters[params::kShoulderWidth] = std::to_string(shoulder_width);
+  parameters[params::kMaximumHeight] = std::to_string(maximum_height);
+  parameters[params::kInertialToBackendFrameTranslation] = inertial_to_backend_frame_translation.to_str();
   return parameters;
 }
 


### PR DESCRIPTION
Related to https://github.com/maliput/maliput_documentation/issues/124

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
 - Move the builder's keys to a `params.h` file in a way that all the backends are documented equally.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
