### PR TITLE
Removes maliput::test_utilities dependency.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,10 +9,10 @@ macro(add_dependencies_to_test target)
       target_include_directories(${target}
         PRIVATE
           ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/test
       )
 
       target_link_libraries(${target}
-          maliput::test_utilities
           maliput_dragway::maliput_dragway
       )
     endif()

--- a/test/assert_compare.h
+++ b/test/assert_compare.h
@@ -1,0 +1,48 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <gtest/gtest.h>
+#include <maliput/common/compare.h>
+
+namespace maliput {
+namespace dragway {
+namespace test {
+
+template <typename T>
+::testing::AssertionResult AssertCompare(const maliput::common::ComparisonResult<T>& res) {
+  if (!res.message.has_value()) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << res.message.value();
+}
+
+}  // namespace test
+}  // namespace dragway
+}  // namespace maliput

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -8,6 +8,7 @@ macro(add_dependencies_to_test target)
       target_include_directories(${target}
         PRIVATE
           ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/test
       )
 
       # To avoid a false positive when running ubsan the symbols must be exported
@@ -26,7 +27,6 @@ macro(add_dependencies_to_test target)
       target_link_libraries(${target}
           maliput_dragway::maliput_dragway
           maliput::plugin
-          maliput::test_utilities
       )
     endif()
 endmacro()

--- a/test/plugin/road_network_plugin_test.cc
+++ b/test/plugin/road_network_plugin_test.cc
@@ -34,22 +34,26 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/road_network.h>
 #include <maliput/api/segment.h>
+#include <maliput/math/compare.h>
 #include <maliput/plugin/maliput_plugin.h>
 #include <maliput/plugin/maliput_plugin_manager.h>
 #include <maliput/plugin/maliput_plugin_type.h>
 #include <maliput/plugin/road_network_loader.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace dragway {
 namespace {
+
+using maliput::dragway::test::AssertCompare;
 
 GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
   setenv("MALIPUT_PLUGIN_PATH", DEF_ROAD_NETWORK_PLUGIN, 1);
@@ -81,8 +85,8 @@ GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
   ASSERT_NE(nullptr, rn);
   const api::RoadGeometry* dragway_rg = rn->road_geometry();
   EXPECT_NE(nullptr, dragway_rg);
-  EXPECT_TRUE(math::test::CompareVectors(math::Vector3{1., 2.5, -4.7},
-                                         dragway_rg->inertial_to_backend_frame_translation(), kTolerance));
+  EXPECT_TRUE(AssertCompare(maliput::math::CompareVectors(
+      math::Vector3{1., 2.5, -4.7}, dragway_rg->inertial_to_backend_frame_translation(), kTolerance)));
   const api::Junction* junction = dragway_rg->junction(0);
   ASSERT_NE(nullptr, junction);
   const api::Segment* segment = junction->segment(0);
@@ -91,10 +95,10 @@ GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
   const api::Lane* lane = segment->lane(0);
   ASSERT_NE(nullptr, lane);
   EXPECT_EQ(10., lane->length());
-  EXPECT_TRUE(api::test::IsRBoundsClose(api::RBounds(-3.7 / 2, 3.7 / 2), lane->lane_bounds(0.), kTolerance));
-  EXPECT_TRUE(
-      api::test::IsRBoundsClose(api::RBounds(-3.7 / 2 - 3., 3.7 / 2 + 3.7 + 3.), lane->segment_bounds(0.), kTolerance));
-  EXPECT_TRUE(api::test::IsHBoundsClose(api::HBounds(0., 5.2), lane->elevation_bounds(0., 0.), kTolerance));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(api::RBounds(-3.7 / 2, 3.7 / 2), lane->lane_bounds(0.), kTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      api::IsRBoundsClose(api::RBounds(-3.7 / 2 - 3., 3.7 / 2 + 3.7 + 3.), lane->segment_bounds(0.), kTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsHBoundsClose(api::HBounds(0., 5.2), lane->elevation_bounds(0., 0.), kTolerance)));
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/maliput/maliput/issues/602

## Summary
 - Uses compare methods instead.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/bc261d73fcf1f6f3c9b41176a714c6b8/raw/ece764bab2689633a888ee8feecb93634b6790a6/maliput_dragway.repos